### PR TITLE
Add reference verison for Isaac Sim 4.2 (and changelog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+# main
+
+# ref-4.2
+
+Release targeting Isaac Sim 4.2
+
+- Added modular state capture
+- Added state writer class
+- Added state reader class
+- Added support for H1
+- Added support for Jetbot
+- Added support for Spot 
+- Added support for Carter
+- Added keyboard teleop scenario
+- Added gamepad teleop scenario
+- Added path following scenario
+- Added random acceleration scenario
+- Added initial OV extension for launching scenarios and recording data
+- Added replay rendering scripts
+- Added data loading examples
+- Added workflow documentation


### PR DESCRIPTION
This branch adds a changelog to capture the initial release features, and tag the version targeting Isaac Sim 4.2.

This is intended to be merged before we rebase / merge Isaac Sim 4.5 target, so we can keep track of changes, and back-reference previous versions.