### PR TITLE
added support for capturing camera pose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # main
 
+- Added camera world pose to state
+
 # ref-4.5
 
 Release targeting Isaac Sim 4.5

--- a/README.md
+++ b/README.md
@@ -398,6 +398,8 @@ The state_dict has the following schema
     "robot.front_camera.left.depth_image": np.ndarray,               # [HxW], np.fp32 - Depth in meters
     "robot.front_camera.left.segmentation_image": np.ndarray,        # [HxW], np.uint8 - Segmentation class index
     "robot.front_camera.left.segmentation_info": dict,               # see Isaac replicator segmentation info format
+    "robot.front_camera.left.position": np.ndarray,                  # [3] - XYZ camera world position
+    "robot.front_camera.left.orientation": np.ndarray,               # [4] - Quaternion camera world orientation
     ...
 }
 ```

--- a/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/sensors.py
+++ b/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/sensors.py
@@ -19,6 +19,7 @@ from typing import Tuple
 
 
 import omni.replicator.core as rep
+from isaacsim.core.prims import SingleXFormPrim as XFormPrim
 
 
 from omni.ext.mobility_gen.utils.global_utils import get_stage
@@ -48,11 +49,14 @@ class Camera(Sensor):
         self._rgb_annotator = None
         self._segmentation_annotator = None
         self._depth_annotator = None
+        self._xform_prim = XFormPrim(self._prim_path)
 
         self.rgb_image = Buffer(tags=["rgb"])
         self.segmentation_image = Buffer(tags=["segmentation"])
         self.segmentation_info = Buffer()
         self.depth_image = Buffer(tags=["depth"])
+        self.position = Buffer()
+        self.orientation = Buffer()
 
     def enable_rendering(self):
         
@@ -126,6 +130,11 @@ class Camera(Sensor):
             self.depth_image.set_value(
                 self._depth_annotator.get_data()
             )
+
+        position, orientation = self._xform_prim.get_world_pose()
+        self.position.set_value(position)
+        self.orientation.set_value(orientation)
+        
         super().update_state()
 
 


### PR DESCRIPTION
This PR adds the camera world pose to the state dictionary.

Tested by visualizing data recorded, the trajectories make sense, left/right camera in stereo are slightly offset and centered around robot pose.