### PR TITLE
Cherry pick gradio fix to dev-external-occupancy-map-generation

### DIFF
--- a/examples/04_visualize_gradio.py
+++ b/examples/04_visualize_gradio.py
@@ -100,11 +100,11 @@ with gr.Blocks(title="MobilityGen - Data Explorer", fill_height=True) as demo:
                 with gr.Row(equal_height=True):
                     map_plot = gr.Plot(scale=2, show_label=False)
                     with gr.Column(scale=1):
-                        left_rgb = gr.Image(show_label=False, show_download_button=False)
-                        left_depth = gr.Image(show_label=False, show_download_button=False)
+                        left_rgb = gr.Image(show_label=False)
+                        left_depth = gr.Image(show_label=False)
                     with gr.Column(scale=1):
-                        right_rgb = gr.Image(show_label=False, show_download_button=False)
-                        right_depth = gr.Image(show_label=False, show_download_button=False)
+                        right_rgb = gr.Image(show_label=False)
+                        right_depth = gr.Image(show_label=False)
                 with gr.Row():
                     slider = gr.Slider(label="Timestep", minimum=0, maximum=0, step=1)
 


### PR DESCRIPTION
Remove show_download_button parameter from gr.Image calls as it was removed in Gradio 5.0. This fixes the TypeError when running the example with modern Gradio versions.