### PR TITLE
fix: return nonzero exit code on Python download failure

### DIFF
--- a/tools/packman/packman
+++ b/tools/packman/packman
@@ -103,7 +103,7 @@ install_python()
 			tar -xf "/tmp/python@$PYTHON_PACKAGE.tar.gz" -C "$PYTHON_INSTALL_FOLDER"
 		else
 			echo "Failed downloading the Python interpreter"
-			exit $?
+			exit 1
 		fi
 	fi
 }


### PR DESCRIPTION
This PR addresses the following issue in `tools/packman/packman`: return nonzero exit code on Python download failure.

## Changes
- `tools/packman/packman`: return nonzero exit code on Python download failure.

## Details
**Before:**
```
		else
			echo "Failed downloading the Python interpreter"
			exit $?
		fi
```

**After:**
```
		else
			echo "Failed downloading the Python interpreter"
			exit 1
		fi
```