### PR TITLE
fix: exit with error when provided app path is missing

### DIFF
--- a/tools/scripts/link_app.py
+++ b/tools/scripts/link_app.py
@@ -77,6 +77,7 @@ if __name__ == "__main__":
 
     if not os.path.exists(path):
         print(f"Provided path doesn't exist: {path}")
+        sys.exit(1)
     else:
         SCRIPT_ROOT = os.path.dirname(os.path.realpath(__file__))
         create_link(f"{SCRIPT_ROOT}/../../app", path)


### PR DESCRIPTION
This PR addresses the following issue in `tools/scripts/link_app.py`: exit with error when provided app path is missing.

## Changes
- `tools/scripts/link_app.py`: exit with error when provided app path is missing.

## Details
**Before:**
```
    if not os.path.exists(path):
        print(f"Provided path doesn't exist: {path}")
    else:
        SCRIPT_ROOT = os.path.dirname(os.path.realpath(__file__))
        create_link(f"{SCRIPT_ROOT}/../../app", path)
        print("Success!")
```

**After:**
```
    if not os.path.exists(path):
        print(f"Provided path doesn't exist: {path}")
        sys.exit(1)
    else:
        SCRIPT_ROOT = os.path.dirname(os.path.realpath(__file__))
        create_link(f"{SCRIPT_ROOT}/../../app", path)
        print("Success!")
```