### PR TITLE
fix: quote target path in bootstrap fetch to handle spaces

### DIFF
--- a/tools/packman/bootstrap/fetch_file_from_packman_bootstrap.cmd
+++ b/tools/packman/bootstrap/fetch_file_from_packman_bootstrap.cmd
@@ -20,11 +20,11 @@
 @echo Fetching %PACKAGE_NAME% ...
 
 @powershell -ExecutionPolicy ByPass -NoLogo -NoProfile -File "%~dp0download_file_from_url.ps1" ^
-    -source "http://bootstrap.packman.nvidia.com/%PACKAGE_NAME%" -output %TARGET_PATH%
+    -source "http://bootstrap.packman.nvidia.com/%PACKAGE_NAME%" -output "%TARGET_PATH%"
 :: A bug in powershell prevents the errorlevel code from being set when using the -File execution option
 :: We must therefore do our own failure analysis, basically make sure the file exists and is larger than 0 bytes:
-@if not exist %TARGET_PATH% goto ERROR_DOWNLOAD_FAILED
-@if %~z2==0 goto ERROR_DOWNLOAD_FAILED
+@if not exist "%TARGET_PATH%" goto ERROR_DOWNLOAD_FAILED
+@if "%~z2"=="0" goto ERROR_DOWNLOAD_FAILED
 
 @endlocal
 @exit /b 0


### PR DESCRIPTION
This PR addresses the following issue in `tools/packman/bootstrap/fetch_file_from_packman_bootstrap.cmd`: quote target path in bootstrap fetch to handle spaces.

## Changes
- `tools/packman/bootstrap/fetch_file_from_packman_bootstrap.cmd`: quote target path in bootstrap fetch to handle spaces.

## Details
**Before:**
```
@powershell -ExecutionPolicy ByPass -NoLogo -NoProfile -File "%~dp0download_file_from_url.ps1" ^
    -source "http://bootstrap.packman.nvidia.com/%PACKAGE_NAME%" -output %TARGET_PATH%
:: A bug in powershell prevents the errorlevel code from being set when using the -File execution option
:: We must therefore do our own failure analysis, basically make sure the file exists and is larger than 0 bytes:
@if not exist %TARGET_PATH% goto ERROR_DOWNLOAD_FAILED
@if %~z2==0 goto ERROR_DOWNLOAD_FAILED
```

**After:**
```
@powershell -ExecutionPolicy ByPass -NoLogo -NoProfile -File "%~dp0download_file_from_url.ps1" ^
    -source "http://bootstrap.packman.nvidia.com/%PACKAGE_NAME%" -output "%TARGET_PATH%"
:: A bug in powershell prevents the errorlevel code from being set when using the -File execution option
:: We must therefore do our own failure analysis, basically make sure the file exists and is larger than 0 bytes:
@if not exist "%TARGET_PATH%" goto ERROR_DOWNLOAD_FAILED
@if "%~z2"=="0" goto ERROR_DOWNLOAD_FAILED
```