### PR TITLE
fix: RGB colormap frames written as BGR to OpenCV video

### DIFF
--- a/scripts/segmentations_to_video.py
+++ b/scripts/segmentations_to_video.py
@@ -116,6 +116,9 @@ def main():
             shading = shading.reshape(height, width, 1)
             colored_frame = (colored_frame * shading).astype(np.uint8)
 
+        # OpenCV video writer expects BGR format
+        colored_frame = cv2.cvtColor(colored_frame, cv2.COLOR_RGB2BGR)
+
         # Write frame to video
         out.write(colored_frame)
 


### PR DESCRIPTION
This PR addresses the following issue in `scripts/segmentations_to_video.py`: RGB colormap frames written as BGR to OpenCV video.

## Changes
- `scripts/segmentations_to_video.py`: RGB colormap frames written as BGR to OpenCV video.

## Details
**Before:**
```
        # Apply combined shading to colored frame
            shading = shading.reshape(height, width, 1)
            colored_frame = (colored_frame * shading).astype(np.uint8)

        # Write frame to video
        out.write(colored_frame)
```

**After:**
```
        # Apply combined shading to colored frame
            shading = shading.reshape(height, width, 1)
            colored_frame = (colored_frame * shading).astype(np.uint8)

        # OpenCV video writer expects BGR format
        colored_frame = cv2.cvtColor(colored_frame, cv2.COLOR_RGB2BGR)

        # Write frame to video
        out.write(colored_frame)
```