### PR TITLE
fix: argparse type=bool cannot parse False from command line

### DIFF
--- a/scripts/replay_directory.py
+++ b/scripts/replay_directory.py
@@ -35,11 +35,20 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--input", type=str, default=None)
     parser.add_argument("--output", type=str, default=None)
-    parser.add_argument("--rgb_enabled", type=bool, default=True)
-    parser.add_argument("--segmentation_enabled", type=bool, default=True)
-    parser.add_argument("--depth_enabled", type=bool, default=True)
-    parser.add_argument("--instance_id_segmentation_enabled", type=bool, default=True)
-    parser.add_argument("--normals_enabled", type=bool, default=False)
+    def _str_to_bool(value):
+        if isinstance(value, bool):
+            return value
+        if value.lower() in ("yes", "true", "t", "y", "1"):
+            return True
+        if value.lower() in ("no", "false", "f", "n", "0"):
+            return False
+        raise argparse.ArgumentTypeError("Boolean value expected.")
+
+    parser.add_argument("--rgb_enabled", type=_str_to_bool, default=True)
+    parser.add_argument("--segmentation_enabled", type=_str_to_bool, default=True)
+    parser.add_argument("--depth_enabled", type=_str_to_bool, default=True)
+    parser.add_argument("--instance_id_segmentation_enabled", type=_str_to_bool, default=True)
+    parser.add_argument("--normals_enabled", type=_str_to_bool, default=False)
     parser.add_argument("--render_rt_subframes", type=int, default=1)
     parser.add_argument("--render_interval", type=int, default=1)
     args = parser.parse_args()


### PR DESCRIPTION
This PR addresses the following issue in `scripts/replay_directory.py`: argparse type=bool cannot parse False from command line.

## Changes
- `scripts/replay_directory.py`: argparse type=bool cannot parse False from command line.

## Details
**Before:**
```
    parser.add_argument("--rgb_enabled", type=bool, default=True)
    parser.add_argument("--segmentation_enabled", type=bool, default=True)
    parser.add_argument("--depth_enabled", type=bool, default=True)
    parser.add_argument("--instance_id_segmentation_enabled", type=bool, default=True)
    parser.add_argument("--normals_enabled", type=bool, default=False)
```

**After:**
```
    def _str_to_bool(value):
        if isinstance(value, bool):
            return value
        if value.lower() in ("yes", "true", "t", "y", "1"):
            return True
        if value.lower() in ("no", "false", "f", "n", "0"):
            return False
        raise argparse.ArgumentTypeError("Boolean value expected.")

    parser.add_argument("--rgb_enabled", type=_str_to_bool, default=True)
    parser.add_argument("--segmentation_enabled", type=_str_to_bool, default=True)
    parser.add_argument("--depth_enabled", type=_str_to_bool, default=True)
    parser.add_argument("--instance_id_segmentation_enabled", type=_str_to_bool, default=True)
    parser.add_argument("--normals_enabled", type=_str_to_bool, default=False)
```