### PR TITLE
fix: old_id_of_unlabeled may be undefined

### DIFF
--- a/scripts/convert_to_lerobot.py
+++ b/scripts/convert_to_lerobot.py
@@ -93,6 +93,7 @@ def remap_segmentation_image(
     old_id_to_label: dict
 ) -> np.ndarray:
     max_id = 0
+    old_id_of_unlabeled = 0
     for old_id, label in old_id_to_label.items():
         assert int(old_id) >= 0
         max_id = max(max_id, int(old_id))


### PR DESCRIPTION
This PR addresses the following issue in `scripts/convert_to_lerobot.py`: old_id_of_unlabeled may be undefined.

## Changes
- `scripts/convert_to_lerobot.py`: old_id_of_unlabeled may be undefined.

## Details
**Before:**
```
def remap_segmentation_image(
    image          : np.ndarray,
    label_to_new_id: dict,
    old_id_to_label: dict
) -> np.ndarray:
    max_id = 0
    for old_id, label in old_id_to_label.items():
        assert int(old_id) >= 0
        max_id = max(max_id, int(old_id))
        if label["class"] == "UNLABELLED":
            old_id_of_unlabeled = int(old_id)

    # TODO: Try the map method instead and compare performance.
    mapping_array = np.zeros(max_id + 1, dtype=np.uint8)
    for old_id, label in old_id_to_label.items():
        new_id = label_to_new_id[label["class"]]
        mapping_array[int(old_id)] = new_id

    # There are some incosistencies in the dataset, where some pixels indicate a certain
    # label but that label wasn't present in the old_id_to_label dictionary. We change all
    # those erroenous pixels to the unlabeled class
    if image.max() > max_id:
        image[image > max_id] = old_id_of_unlabeled
    return mapping_array[image]
```

**After:**
```
def remap_segmentation_image(
    image          : np.ndarray,
    label_to_new_id: dict,
    old_id_to_label: dict
) -> np.ndarray:
    max_id = 0
    old_id_of_unlabeled = 0
    for old_id, label in old_id_to_label.items():
        assert int(old_id) >= 0
        max_id = max(max_id, int(old_id))
        if label["class"] == "UNLABELLED":
            old_id_of_unlabeled = int(old_id)

    # TODO: Try the map method instead and compare performance.
    mapping_array = np.zeros(max_id + 1, dtype=np.uint8)
    for old_id, label in old_id_to_label.items():
        new_id = label_to_new_id[label["class"]]
        mapping_array[int(old_id)] = new_id

    # There are some incosistencies in the dataset, where some pixels indicate a certain
    # label but that label wasn't present in the old_id_to_label dictionary. We change all
    # those erroenous pixels to the unlabeled class
    if image.max() > max_id:
        image[image > max_id] = old_id_of_unlabeled
    return mapping_array[image]
```