### PR TITLE
fix: prim_compute_bbox return annotation omits midpoint tuple

### DIFF
--- a/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/utils/prim_utils.py
+++ b/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/utils/prim_utils.py
@@ -27,14 +27,14 @@ def prim_add_collision(prim: Usd.Prim):
 
 
 def prim_compute_bbox(prim: Usd.Prim, nested: bool = False) -> \
-        tp.Tuple[tp.Tuple[float, float, float], tp.Tuple[float, float, float]]:
+        tp.Tuple[tp.Tuple[float, float, float], tp.Tuple[float, float, float], tp.Tuple[float, float, float]]:
     """Computes the axis-aligned bounding box for a USD prim.
     
     Args:
         prim (Usd.Prim):  The USD prim to compute the bounding box of.
 
     Returns:
-        Tuple[Tuple[float, float, float], Tuple[float, float, float]] The ((min_x, min_y, min_z), (max_x, max_y, max_z)) values of the bounding box.
+        Tuple[Tuple[float, float, float], Tuple[float, float, float], Tuple[float, float, float]] The ((min_x, min_y, min_z), (max_x, max_y, max_z), (mid_x, mid_y, mid_z)) values of the bounding box.
     """
     
     bbox_cache: UsdGeom.BBoxCache = UsdGeom.BBoxCache(


### PR DESCRIPTION
This PR addresses the following issue in `exts/omni.ext.mobility_gen/omni/ext/mobility_gen/utils/prim_utils.py`: prim_compute_bbox return annotation omits midpoint tuple.

## Changes
- `exts/omni.ext.mobility_gen/omni/ext/mobility_gen/utils/prim_utils.py`: prim_compute_bbox return annotation omits midpoint tuple.

## Details
**Before:**
```
def prim_compute_bbox(prim: Usd.Prim, nested: bool = False) -> \
        tp.Tuple[tp.Tuple[float, float, float], tp.Tuple[float, float, float]]:
    """Computes the axis-aligned bounding box for a USD prim.
    
    Args:
        prim (Usd.Prim):  The USD prim to compute the bounding box of.

    Returns:
        Tuple[Tuple[float, float, float], Tuple[float, float, float]] The ((min_x, min_y, min_z), (max_x, max_y, max_z)) values of the bounding box.
    """
```

**After:**
```
def prim_compute_bbox(prim: Usd.Prim, nested: bool = False) -> \
        tp.Tuple[tp.Tuple[float, float, float], tp.Tuple[float, float, float], tp.Tuple[float, float, float]]:
    """Computes the axis-aligned bounding box for a USD prim.
    
    Args:
        prim (Usd.Prim):  The USD prim to compute the bounding box of.

    Returns:
        Tuple[Tuple[float, float, float], Tuple[float, float, float], Tuple[float, float, float]] The ((min_x, min_y, min_z), (max_x, max_y, max_z), (mid_x, mid_y, mid_z)) values of the bounding box.
    """
```