### PR TITLE
fix: disable_rendering leaks instance ID and normals annotators

### DIFF
--- a/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/sensors.py
+++ b/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/sensors.py
@@ -83,6 +83,14 @@ class Camera(Sensor):
             self._segmentation_annotator.detach()
             self._segmentation_annotator = None
 
+        if self._instance_id_segmentation_annotator is not None:
+            self._instance_id_segmentation_annotator.detach()
+            self._instance_id_segmentation_annotator = None
+
+        if self._normals_annotator is not None:
+            self._normals_annotator.detach()
+            self._normals_annotator = None
+
         if self._depth_annotator is not None:
             self._depth_annotator.detach()
             self._depth_annotator = None


### PR DESCRIPTION
This PR addresses the following issue in `exts/omni.ext.mobility_gen/omni/ext/mobility_gen/sensors.py`: disable_rendering leaks instance ID and normals annotators.

## Changes
- `exts/omni.ext.mobility_gen/omni/ext/mobility_gen/sensors.py`: disable_rendering leaks instance ID and normals annotators.

## Details
**Before:**
```
    def disable_rendering(self):
        if self._render_product is None:
            return
        
        if self._rgb_annotator is not None:
            self._rgb_annotator.detach()
            self._rgb_annotator = None
        
        if self._segmentation_annotator is not None:
            self._segmentation_annotator.detach()
            self._segmentation_annotator = None

        if self._depth_annotator is not None:
            self._depth_annotator.detach()
            self._depth_annotator = None

        self._render_product.destroy()
        self._render_product = None
```

**After:**
```
    def disable_rendering(self):
        if self._render_product is None:
            return
        
        if self._rgb_annotator is not None:
            self._rgb_annotator.detach()
            self._rgb_annotator = None
        
        if self._segmentation_annotator is not None:
            self._segmentation_annotator.detach()
            self._segmentation_annotator = None

        if self._instance_id_segmentation_annotator is not None:
            self._instance_id_segmentation_annotator.detach()
            self._instance_id_segmentation_annotator = None

        if self._normals_annotator is not None:
            self._normals_annotator.detach()
            self._normals_annotator = None

        if self._depth_annotator is not None:
            self._depth_annotator.detach()
            self._depth_annotator = None

        self._render_product.destroy()
        self._render_product = None
```