### PR TITLE
fix: concrete scene builder subclasses not registered

### DIFF
--- a/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/scene_builders.py
+++ b/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/scene_builders.py
@@ -93,6 +93,7 @@ class RandomCubeSceneSmall(RandomCubeScene):
 
 
 @SCENE_BUILDERS.register()
+@SCENE_BUILDERS.register()
 class RandomCubeSceneLarge(RandomCubeScene):
     num_cubes: int = 20
     x_boundary: Tuple[float, float] = (-10., 10.)


### PR DESCRIPTION
This PR addresses the following issue in `exts/omni.ext.mobility_gen/omni/ext/mobility_gen/scene_builders.py`: concrete scene builder subclasses not registered.

## Changes
- `exts/omni.ext.mobility_gen/omni/ext/mobility_gen/scene_builders.py`: concrete scene builder subclasses not registered.

## Details
**Before:**
```
class RandomCubeSceneSmall(RandomCubeScene):
```

**After:**
```
@SCENE_BUILDERS.register()
class RandomCubeSceneSmall(RandomCubeScene):
```