### PR TITLE
fix: SpotRobot articulation_path "/" resolves to stage root

### DIFF
--- a/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/robots.py
+++ b/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/robots.py
@@ -554,7 +554,7 @@ class SpotRobot(IsaacLabRobot):
     path_following_target_point_offset_meters: float = 1.0
 
     usd_url = "http://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/4.2/Isaac/Robots/BostonDynamics/spot/spot.usd"
-    articulation_path = "/"
+    articulation_path = ""
     controller_z_offset: float = 0.7
 
     @classmethod


### PR DESCRIPTION
This PR addresses the following issue in `exts/omni.ext.mobility_gen/omni/ext/mobility_gen/robots.py`: SpotRobot articulation_path "/" resolves to stage root.

## Changes
- `exts/omni.ext.mobility_gen/omni/ext/mobility_gen/robots.py`: SpotRobot articulation_path "/" resolves to stage root.

## Details
**Before:**
```
    articulation_path = "/"
```

**After:**
```
    articulation_path = ""
```