### PR TITLE
fix: GridPoseSampler crashes on empty freespace block

### DIFF
--- a/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/pose_samplers.py
+++ b/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/pose_samplers.py
@@ -120,6 +120,8 @@ class GridPoseSampler(PoseSampler):
         # TODO: check no unoccupied
 
         coords = np.argwhere(net_mask)
+        if len(coords) == 0:
+            raise ValueError("Selected grid block contains no freespace pixels")
         random_index = np.random.randint(0, len(coords))
         pixel = coords[random_index]
         pixel = Point2d(x=pixel[1], y=pixel[0])


### PR DESCRIPTION
This PR addresses the following issue in `exts/omni.ext.mobility_gen/omni/ext/mobility_gen/pose_samplers.py`: GridPoseSampler crashes on empty freespace block.

## Changes
- `exts/omni.ext.mobility_gen/omni/ext/mobility_gen/pose_samplers.py`: GridPoseSampler crashes on empty freespace block.

## Details
**Before:**
```
        coords = np.argwhere(net_mask)
        random_index = np.random.randint(0, len(coords))
        pixel = coords[random_index]
```

**After:**
```
        coords = np.argwhere(net_mask)
        if len(coords) == 0:
            raise ValueError("Selected grid block contains no freespace pixels")
        random_index = np.random.randint(0, len(coords))
        pixel = coords[random_index]
```