### PR TITLE
fix: grid block mask applies x/y ranges both to rows

### DIFF
--- a/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/pose_samplers.py
+++ b/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/pose_samplers.py
@@ -112,8 +112,8 @@ class GridPoseSampler(PoseSampler):
         mask = occupancy_map.freespace_mask()
 
         block_mask = np.zeros_like(mask)
-        block_mask[block_x_min:block_x_min+block_size_px] = True
-        block_mask[block_y_min:block_y_min+block_size_px] = True
+        block_mask[:, block_x_min:block_x_min+block_size_px] = True
+        block_mask[block_y_min:block_y_min+block_size_px, :] = True
 
         net_mask = block_mask & mask
 


### PR DESCRIPTION
This PR addresses the following issue in `exts/omni.ext.mobility_gen/omni/ext/mobility_gen/pose_samplers.py`: grid block mask applies x/y ranges both to rows.

## Changes
- `exts/omni.ext.mobility_gen/omni/ext/mobility_gen/pose_samplers.py`: grid block mask applies x/y ranges both to rows.

## Details
**Before:**
```
        block_mask = np.zeros_like(mask)
        block_mask[block_x_min:block_x_min+block_size_px] = True
        block_mask[block_y_min:block_y_min+block_size_px] = True

        net_mask = block_mask & mask
```

**After:**
```
        block_mask = np.zeros_like(mask)
        block_mask[:, block_x_min:block_x_min+block_size_px] = True
        block_mask[block_y_min:block_y_min+block_size_px, :] = True

        net_mask = block_mask & mask
```