### PR TITLE
fix: dilation kernel size is off by one pixel in buffered

### DIFF
--- a/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/occupancy_map.py
+++ b/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/occupancy_map.py
@@ -353,7 +353,7 @@ free_thresh: {free_thresh}
         buffer_distance_pixels = int(buffer_distance_pixels)
         
         radius = buffer_distance_pixels
-        diameter = radius * 2
+        diameter = radius * 2 + 1
         kernel = np.zeros((diameter, diameter), np.uint8)
         cv2.circle(kernel, (radius, radius), radius, 255, -1)
         occupied = self.occupied_mask().astype(np.uint8) * 255


### PR DESCRIPTION
This PR addresses the following issue in `exts/omni.ext.mobility_gen/omni/ext/mobility_gen/occupancy_map.py`: dilation kernel size is off by one pixel in buffered.

## Changes
- `exts/omni.ext.mobility_gen/omni/ext/mobility_gen/occupancy_map.py`: dilation kernel size is off by one pixel in buffered.

## Details
**Before:**
```
        radius = buffer_distance_pixels
        diameter = radius * 2
        kernel = np.zeros((diameter, diameter), np.uint8)
        cv2.circle(kernel, (radius, radius), radius, 255, -1)
```

**After:**
```
        radius = buffer_distance_pixels
        diameter = radius * 2 + 1
        kernel = np.zeros((diameter, diameter), np.uint8)
        cv2.circle(kernel, (radius, radius), radius, 255, -1)
```