### PR TITLE
fix: get_button_values creates scalar array instead of empty array

### DIFF
--- a/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/inputs.py
+++ b/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/inputs.py
@@ -210,7 +210,7 @@ class GamepadDriver(object):
         return np.array([axis.value for axis in self.axes])
     
     def get_button_values(self) -> np.ndarray:
-        return np.ndarray([])
+        return np.array([])
     
     
 #=========================================================


### PR DESCRIPTION
This PR addresses the following issue in `exts/omni.ext.mobility_gen/omni/ext/mobility_gen/inputs.py`: get_button_values creates scalar array instead of empty array.

## Changes
- `exts/omni.ext.mobility_gen/omni/ext/mobility_gen/inputs.py`: get_button_values creates scalar array instead of empty array.

## Details
**Before:**
```
    def get_button_values(self) -> np.ndarray:
        return np.ndarray([])
```

**After:**
```
    def get_button_values(self) -> np.ndarray:
        return np.array([])
```