### PR TITLE
fix: physics callback leaks when rebuilding scenario

### DIFF
--- a/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/extension.py
+++ b/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/extension.py
@@ -162,6 +162,12 @@ class MobilityGenExtension(omni.ext.IExt):
         self.recording_step_label.text = "Current recording duration: "
 
     def clear_scenario(self):
+        world = get_world()
+        if world is not None:
+            try:
+                world.remove_physics_callback("scenario_physics")
+            except Exception:
+                pass
         self.scenario = None
         self.cached_stage_path = None
 


### PR DESCRIPTION
This PR addresses the following issue in `exts/omni.ext.mobility_gen/omni/ext/mobility_gen/extension.py`: physics callback leaks when rebuilding scenario.

## Changes
- `exts/omni.ext.mobility_gen/omni/ext/mobility_gen/extension.py`: physics callback leaks when rebuilding scenario.

## Details
**Before:**
```
    def clear_scenario(self):
        self.scenario = None
        self.cached_stage_path = None
```

**After:**
```
    def clear_scenario(self):
        world = get_world()
        if world is not None:
            try:
                world.remove_physics_callback("scenario_physics")
            except Exception:
                pass
        self.scenario = None
        self.cached_stage_path = None
```