### PR TITLE
fix: reset() crashes when no scenario is built

### DIFF
--- a/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/extension.py
+++ b/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/extension.py
@@ -176,6 +176,8 @@ class MobilityGenExtension(omni.ext.IExt):
         self.clear_recording()
 
     def reset(self):
+        if self.scenario is None:
+            return
         self.writer = None
         self.scenario.reset()
         if self.recording_enabled:


### PR DESCRIPTION
This PR addresses the following issue in `exts/omni.ext.mobility_gen/omni/ext/mobility_gen/extension.py`: reset() crashes when no scenario is built.

## Changes
- `exts/omni.ext.mobility_gen/omni/ext/mobility_gen/extension.py`: reset() crashes when no scenario is built.

## Details
**Before:**
```
    def reset(self):
        self.writer = None
        self.scenario.reset()
        if self.recording_enabled:
            self.start_new_recording()
```

**After:**
```
    def reset(self):
        if self.scenario is None:
            return
        self.writer = None
        self.scenario.reset()
        if self.recording_enabled:
            self.start_new_recording()
```