### PR TITLE
fix: remove_physics_callback called with extra argument

### DIFF
--- a/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/extension.py
+++ b/exts/omni.ext.mobility_gen/omni/ext/mobility_gen/extension.py
@@ -140,7 +140,11 @@ class MobilityGenExtension(omni.ext.IExt):
         self.keyboard.disconnect()
         self.gamepad.disconnect()
         world = get_world()
-        world.remove_physics_callback("scenario_physics", self.on_physics)
+        if world is not None:
+            try:
+                world.remove_physics_callback("scenario_physics")
+            except Exception:
+                pass
 
     def start_new_recording(self):
         recording_name = datetime.datetime.now().isoformat()


### PR DESCRIPTION
This PR addresses the following issue in `exts/omni.ext.mobility_gen/omni/ext/mobility_gen/extension.py`: remove_physics_callback called with extra argument.

## Changes
- `exts/omni.ext.mobility_gen/omni/ext/mobility_gen/extension.py`: remove_physics_callback called with extra argument.

## Details
**Before:**
```
        world = get_world()
        world.remove_physics_callback("scenario_physics", self.on_physics)
```

**After:**
```
        world = get_world()
        if world is not None:
            try:
                world.remove_physics_callback("scenario_physics")
            except Exception:
                pass
```