### PR TITLE
fix: automodule directive has stray quote in docs/index.rst

### DIFF
--- a/exts/omni.ext.mobility_gen/docs/index.rst
+++ b/exts/omni.ext.mobility_gen/docs/index.rst
@@ -11,7 +11,7 @@ Example of Python only extension
    CHANGELOG
 
 
-.. automodule::"omni.ext.mobility_gen"
+.. automodule:: omni.ext.mobility_gen"
     :platform: Windows-x86_64, Linux-x86_64
     :members:
     :undoc-members:


### PR DESCRIPTION
This PR addresses the following issue in `exts/omni.ext.mobility_gen/docs/index.rst`: automodule directive has stray quote in docs/index.rst.

## Changes
- `exts/omni.ext.mobility_gen/docs/index.rst`: automodule directive has stray quote in docs/index.rst.

## Details
**Before:**
```
.. automodule::"omni.ext.mobility_gen
```

**After:**
```
.. automodule:: omni.ext.mobility_gen
```