### PR TITLE
fix: YAML origin saved as tuple instead of ROS list

### DIFF
--- a/examples/occupancy_map.py
+++ b/examples/occupancy_map.py
@@ -66,7 +66,7 @@ class OccupancyMap:
 """
 image: {image_filename}
 resolution: {resolution}
-origin: {origin}
+origin: [{origin[0]}, {origin[1]}, {origin[2]}]
 negate: {negate}
 occupied_thresh: {occupied_thresh}
 free_thresh: {free_thresh}


### PR DESCRIPTION
This PR addresses the following issue in `examples/occupancy_map.py`: YAML origin saved as tuple instead of ROS list.

## Changes
- `examples/occupancy_map.py`: YAML origin saved as tuple instead of ROS list.

## Details
**Before:**
```
origin: {origin}
```

**After:**
```
origin: [{origin[0]}, {origin[1]}, {origin[2]}]
```