### PR TITLE
fix: returning new gr.Slider fails to update existing slider

### DIFF
--- a/examples/04_visualize_gradio.py
+++ b/examples/04_visualize_gradio.py
@@ -84,8 +84,8 @@ def update_recording(name: str):
     global context
     context = Context(name)
     main = context.update(index=0)
-    slider = gr.Slider(value=0, minimum=0, maximum=len(context.reader) - 1, step=1)
-    return main + [slider]
+    slider_update = gr.update(value=0, minimum=0, maximum=len(context.reader) - 1, step=1)
+    return main + [slider_update]
 
 
 def update_step(index: int):


### PR DESCRIPTION
This PR addresses the following issue in `examples/04_visualize_gradio.py`: returning new gr.Slider fails to update existing slider.

## Changes
- `examples/04_visualize_gradio.py`: returning new gr.Slider fails to update existing slider.

## Details
**Before:**
```
    slider = gr.Slider(value=0, minimum=0, maximum=len(context.reader) - 1, step=1)
    return main + [slider]
```

**After:**
```
    slider_update = gr.update(value=0, minimum=0, maximum=len(context.reader) - 1, step=1)
    return main + [slider_update]
```