### PR TITLE
fix: argparse type=bool incorrectly parses boolean flag

### DIFF
--- a/examples/02_draw_images.py
+++ b/examples/02_draw_images.py
@@ -20,7 +20,7 @@ from reader import Reader
 
 parser = argparse.ArgumentParser()
 parser.add_argument("recording_path")
-parser.add_argument("--normals_enabled", type=bool, default=False)
+parser.add_argument("--normals_enabled", action="store_true")
 args = parser.parse_args()
 
 reader = Reader(recording_path=args.recording_path)


### PR DESCRIPTION
This PR addresses the following issue in `examples/02_draw_images.py`: argparse type=bool incorrectly parses boolean flag.

## Changes
- `examples/02_draw_images.py`: argparse type=bool incorrectly parses boolean flag.

## Details
**Before:**
```
parser.add_argument("--normals_enabled", type=bool, default=False)
```

**After:**
```
parser.add_argument("--normals_enabled", action="store_true")
```