### PR TITLE
fix: normals example uses backslash as path separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ In case you're interested, each recording is represented as a directory with the
             robot.front_camera.right.segmentation_image/
                 ...
         normals/
-            robot.front_camera.left.normals_image\
+            robot.front_camera.left.normals_image/
                 00000000.npy
                 00000001.npy
                 ...


### PR DESCRIPTION
This PR corrects the documentation in `README.md`: normals example uses backslash as path separator.

## Changes
- `README.md`: normals example uses backslash as path separator.

## Details
**Before:**
```
        normals/
            robot.front_camera.left.normals_image\
                00000000.npy
                00000001.npy
                ...
```

**After:**
```
        normals/
            robot.front_camera.left.normals_image/
                00000000.npy
                00000001.npy
                ...
```