### PR TITLE
fix: duplicate step number 2 in custom robot instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ The general workflow is as follows:
 
 1. Subclass the [Robot](exts/omni.ext.mobility_gen/omni/ext/mobility_gen/robots.py) class.
 2. Implement the ``build()`` method.  This method is responsible for adding the robot to the USD stage.
-2. Implement the ``write_action()`` method.  This method performs the logic of applying the linear, angular velocity command.
+3. Implement the ``write_action()`` method.  This method performs the logic of applying the linear, angular velocity command.
 3. Overwrite the common class parameters (like ``physics_dt``, ``occupancy_map_z_min``, etc.)
 4. Register the robot class by using the ``ROBOT.register()`` decorator.  This makes the custom robot discoverable.
 


### PR DESCRIPTION
This PR corrects the documentation in `README.md`: duplicate step number 2 in custom robot instructions.

## Changes
- `README.md`: duplicate step number 2 in custom robot instructions.

## Details
**Before:**
```
2. Implement the ``build()`` method.  This method is responsible for adding the robot to the USD stage.
2. Implement the ``write_action()`` method.  This method performs the logic of applying the linear, angular velocity command.
```

**After:**
```
2. Implement the ``build()`` method.  This method is responsible for adding the robot to the USD stage.
3. Implement the ``write_action()`` method.  This method performs the logic of applying the linear, angular velocity command.
```